### PR TITLE
Add tests for product URL and search API

### DIFF
--- a/exeshop/settings.py
+++ b/exeshop/settings.py
@@ -129,7 +129,7 @@ OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o")
 
 # Мова / час
 LANGUAGE_CODE = "uk"
-TIME_ZONE = "Europe/Kiev"
+TIME_ZONE = "Europe/Kyiv"
 USE_I18N = True
 USE_TZ = True
 

--- a/shop/models.py
+++ b/shop/models.py
@@ -22,6 +22,10 @@ class Product(models.Model):
     rating = models.PositiveSmallIntegerField(default=0)   # 0-5
     in_stock = models.BooleanField(default=True)
 
+    def get_absolute_url(self):
+        """Return the canonical product URL."""
+        return reverse("shop:product_detail", args=[self.slug])
+
     def image_tag(self):
         if self.image:
             return mark_safe(f'<img src="{self.image.url}" width="60" />')

--- a/shop/tests.py
+++ b/shop/tests.py
@@ -1,3 +1,45 @@
+from django.urls import reverse
 from django.test import TestCase
 
-# Create your tests here.
+from .models import Category, Product
+
+
+class ProductModelTests(TestCase):
+    def setUp(self):
+        self.category = Category.objects.create(name="Cat", slug="cat")
+        self.product = Product.objects.create(
+            category=self.category,
+            name="Test Product",
+            slug="test-product",
+            description="desc",
+            price="9.99",
+        )
+
+    def test_get_absolute_url_returns_correct_path(self):
+        expected = reverse("shop:product_detail", args=[self.product.slug])
+        self.assertEqual(self.product.get_absolute_url(), expected)
+
+
+class ApiSearchTests(TestCase):
+    def setUp(self):
+        self.category = Category.objects.create(name="Other", slug="other")
+        self.product = Product.objects.create(
+            category=self.category,
+            name="Awesome Widget",
+            slug="awesome-widget",
+            description="desc",
+            price="1.99",
+        )
+
+    def test_api_search_returns_expected_structure(self):
+        url = reverse("shop:api_search")
+        response = self.client.get(url, {"q": "Awesome"})
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(
+            data[0],
+            {"label": self.product.name, "url": self.product.get_absolute_url()},
+        )
+


### PR DESCRIPTION
## Summary
- implement `Product.get_absolute_url`
- fix timezone setting to Europe/Kyiv
- add Django tests for product URL and search API

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_684743cc4960832593d105d06b9eaf89