### PR TITLE
Add docstring to ChatConsumer

### DIFF
--- a/shop/consumers.py
+++ b/shop/consumers.py
@@ -1,6 +1,8 @@
 import json
 from channels.generic.websocket import AsyncWebsocketConsumer
 
+"""Handles WebSocket chat messages and currently echoes user input."""
+
 class ChatConsumer(AsyncWebsocketConsumer):
     async def connect(self):
         await self.accept()


### PR DESCRIPTION
## Summary
- add module docstring that explains ChatConsumer handles WebSocket messages

## Testing
- `python -m py_compile shop/consumers.py`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684743c1892483259d6dbf4b388c1907