### PR TITLE
Fix typo in chat_api exception comment

### DIFF
--- a/shop/chat_api.py
+++ b/shop/chat_api.py
@@ -174,7 +174,7 @@ def _call_gpt(self, query: str) -> str:
         # Гарантуємо повернення рядка згідно з анотацією  
         return resp.choices[0].message.content.strip()
     except Exception as exc:  # noqa: BLE001  
-        # Логуємо трейcбек та текст помилки        logger.exception("OpenAI error: %s", exc)  
+        # Логуємо трейсбек та текст помилки        logger.exception("OpenAI error: %s", exc)  
         # Повертаємо безпечне повідомлення для користувача  
         return "⚠️ Вибачте, не вдалося отримати відповідь."
 


### PR DESCRIPTION
## Summary
- fix a small typo in the exception handler comment in `chat_api.py`

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_68475d247b648325b99db635c719324c