### PR TITLE
Improve chat UI

### DIFF
--- a/static/shop/css/chat.css
+++ b/static/shop/css/chat.css
@@ -1,48 +1,81 @@
-#dango-chat-toggle {
-    transition: box-shadow 0.2s;
+.chatbox {
+    position: fixed;
+    right: 2rem;
+    bottom: 2rem;
+    width: 350px;
+    min-width: 240px;
+    max-width: 90vw;
+    height: 340px;
+    min-height: 180px;
+    max-height: 80vh;
+    background: #ffffffcc;
+    backdrop-filter: blur(12px);
+    border-radius: 12px;
+    border: 2px solid #ffd500;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.15);
+    overflow: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(40px) scale(0.97);
+    transition: all .35s cubic-bezier(.6,0,.2,1);
+    z-index: 1000;
 }
-#dango-chat-toggle:hover {
-    box-shadow: 0 8px 16px #e6001266;
+.chat-header {
+    background: #ffd500;
+    color: #222;
+    font-weight: bold;
+    padding: 10px 12px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    cursor: move;
+    user-select: none;
 }
-#dango-chat-widget {
-    animation: chatOpen 0.23s;
-}
-@keyframes chatOpen {
-    from {transform: translateY(30px) scale(0.92); opacity:0;}
-    to {transform: none; opacity:1;}
-}
-#dango-chat-messages {
+.chat-messages {
+    height: 190px;
     overflow-y: auto;
-    min-height: 120px;
-    max-height: 340px;
+    padding: 10px;
+    font-size: 14px;
+    background: #fcfcfc;
 }
-.dango-message {
-    background: #f6f6f6;
-    border-radius: 16px;
-    padding: 10px 14px;
-    margin-bottom: 8px;
-    display: inline-block;
-    max-width: 90%;
+.chat-form {
+    padding: 12px 10px 10px 10px;
+    background: #fff;
+    border-top: 1px solid #f5d500;
 }
-.dango-message.bot {
-    background: #e9f2ff;
-    color: #14467a;
-    margin-right: auto;
+.chat-fab {
+    position: fixed;
+    right: 2rem;
+    bottom: 2rem;
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    background: #ffd500;
+    border: none;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.2);
+    cursor: pointer;
+    font-size: 2rem;
+    z-index: 999;
 }
-.dango-message.user {
-    background: #e60012;
-    color: #fff;
-    margin-left: auto;
-    text-align: right;
+.chat-fab:hover {
+    box-shadow: 0 6px 26px rgba(0,0,0,0.25);
+}
+.chat-resizer {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    width: 16px;
+    height: 16px;
+    cursor: se-resize;
 }
 @media (max-width: 480px) {
-    #dango-chat-widget {
+    .chatbox {
         right: 4vw !important;
         bottom: 4vw !important;
         width: 96vw !important;
         min-width: 0;
     }
-    #dango-chat-toggle {
+    .chat-fab {
         right: 4vw !important;
         bottom: 4vw !important;
     }

--- a/static/shop/css/styles.css
+++ b/static/shop/css/styles.css
@@ -1,19 +1,32 @@
+.modern-body {
+  font-family: 'Inter', 'Noto Sans JP', sans-serif;
+  background: linear-gradient(120deg,#f0f0f3 0%,#ffffff 100%);
+  min-height: 100vh;
+}
+
+.navbar-modern {
+  background: rgba(255,255,255,0.8);
+  backdrop-filter: blur(6px);
+  box-shadow: 0 2px 12px rgba(0,0,0,0.05);
+  border: none;
+}
+
 .product-card {
   width: 170px;      /* або max-width: 180px; */
   min-width: 140px;
   margin: 10px;
-  padding: 10px 10px 15px 10px;
-  border-radius: 16px;
-  box-shadow: 0 2px 8px #0001;
+  padding: 12px 12px 16px 12px;
+  border-radius: 18px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.05);
   background: #fff;
-  transition: box-shadow .2s, transform .2s;
+  transition: box-shadow .25s, transform .25s;
   display: flex;
   flex-direction: column;
   align-items: center;
 }
 .product-card:hover {
-  box-shadow: 0 4px 16px #0002;
-  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.08);
+  transform: translateY(-4px);
 }
 
 .product-card img {

--- a/static/shop/js/chat.js
+++ b/static/shop/js/chat.js
@@ -7,6 +7,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const chatInput    = document.getElementById('chat-input');
     const chatMessages = document.getElementById('chat-messages');
     if (!chatbox || !fab || !closeBtn || !chatForm || !chatInput || !chatMessages) return;
+    const header       = chatbox.querySelector('.chat-header');
+    const resizer      = chatbox.querySelector('.chat-resizer');
 
     /* ── show / hide ───────────────────────────────────────── */
     fab.addEventListener('click', () => {
@@ -19,6 +21,50 @@ document.addEventListener('DOMContentLoaded', () => {
         chatbox.style.pointerEvents = 'none';
         fab.style.display = '';
     });
+
+    /* ── dragging ─────────────────────────────────────────── */
+    if (header) {
+        header.addEventListener('pointerdown', e => {
+            if (e.button !== 0) return;
+            e.preventDefault();
+            const rect = chatbox.getBoundingClientRect();
+            const shiftX = e.clientX - rect.left;
+            const shiftY = e.clientY - rect.top;
+            const onMove = ev => {
+                chatbox.style.left = ev.clientX - shiftX + 'px';
+                chatbox.style.top = ev.clientY - shiftY + 'px';
+                chatbox.style.right = 'auto';
+                chatbox.style.bottom = 'auto';
+            };
+            const onUp = () => {
+                document.removeEventListener('pointermove', onMove);
+            };
+            document.addEventListener('pointermove', onMove);
+            document.addEventListener('pointerup', onUp, { once: true });
+        });
+    }
+
+    /* ── resizing ─────────────────────────────────────────── */
+    if (resizer) {
+        resizer.addEventListener('pointerdown', e => {
+            e.preventDefault();
+            const startW = chatbox.offsetWidth;
+            const startH = chatbox.offsetHeight;
+            const startX = e.clientX;
+            const startY = e.clientY;
+            const onMove = ev => {
+                const newW = Math.max(240, startW + ev.clientX - startX);
+                const newH = Math.max(180, startH + ev.clientY - startY);
+                chatbox.style.width = newW + 'px';
+                chatbox.style.height = newH + 'px';
+            };
+            const onUp = () => {
+                document.removeEventListener('pointermove', onMove);
+            };
+            document.addEventListener('pointermove', onMove);
+            document.addEventListener('pointerup', onUp, { once: true });
+        });
+    }
 
     /* ── local history ────────────────────────────────────── */
     let history = [];

--- a/templates/shop/base.html
+++ b/templates/shop/base.html
@@ -8,14 +8,15 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
   <link href="https://fonts.googleapis.com/css?family=Noto+Sans+JP:400,700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{% static 'shop/css/styles.css' %}">
   <link rel="stylesheet" href="{% static 'shop/css/chat.css' %}">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   {% block meta_description %}{% endblock %}
   {% block extra_head %}{% endblock %}
 </head>
-<body>
-<nav class="navbar navbar-expand-lg navbar-light shadow-sm py-2" style="background:#fffdf6;border-bottom:2px solid #e60012">
+<body class="modern-body">
+<nav class="navbar navbar-expand-lg navbar-light shadow-sm py-2 navbar-modern">
   <div class="container">
     <a class="navbar-brand fw-bold" href="{% url 'shop:home' %}" style="color:#e60012">Dango</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav"><span class="navbar-toggler-icon"></span></button>

--- a/templates/shop/chat_widget.html
+++ b/templates/shop/chat_widget.html
@@ -1,24 +1,18 @@
-<div id="chatbox"
-     style="position:fixed; right:32px; bottom:32px; width:350px; min-width:240px; max-width:90vw;
-            height:340px; min-height:180px; max-height:80vh; background:#fff;
-            border-radius:12px; box-shadow: 0 6px 32px #0004;
-            border:2px solid #ffd500; z-index:1000; overflow:hidden;
-            opacity:0; pointer-events:none; transform:translateY(40px) scale(0.97); transition:all .35s cubic-bezier(.6,0,.2,1);">
-    <div style="background:#ffd500; color:#222; font-weight:bold; padding:10px 12px; display:flex; align-items:center; justify-content:space-between;">
+<div id="chatbox" class="chatbox">
+    <div class="chat-header">
         <span>💬 Чат-бот Dango</span>
-        <button id="chat-close-btn" style="background:none;border:none;font-size:18px;cursor:pointer;">✕</button>
+        <button id="chat-close-btn" class="btn-close" aria-label="Close"></button>
     </div>
-    <div id="chat-messages" style="height:190px; overflow-y:auto; padding:10px; font-size:14px; background:#fcfcfc;"></div>
-    <form id="chat-form" method="post" style="display:flex;gap:8px;padding:12px 10px 10px 10px;background:#fff;border-top:1px solid #f5d500;">
+    <div id="chat-messages" class="chat-messages"></div>
+    <form id="chat-form" method="post" class="chat-form d-flex gap-2">
         {% csrf_token %}
-        <input id="chat-input" class="form-control" type="text" autocomplete="off" maxlength="200"
-               placeholder="Ваше питання..." style="width:75%; font-size:14px;">
-        <button class="btn btn-warning" type="submit" style="font-weight:bold;">Відправити</button>
+        <input id="chat-input" class="form-control flex-grow-1" type="text" autocomplete="off" maxlength="200"
+               placeholder="Ваше питання...">
+        <button class="btn btn-warning fw-bold" type="submit">Відправити</button>
     </form>
+    <div class="chat-resizer"></div>
 </div>
 <!-- Кнопка для виклику -->
-<button id="chat-fab"
-        style="position:fixed; right:32px; bottom:32px; width:52px; height:52px; border-radius:50%;
-        background:#ffd500; border:none; box-shadow:0 4px 24px #0003; cursor:pointer; font-size:2rem; z-index:999;">
+<button id="chat-fab" class="chat-fab">
     💬
 </button>


### PR DESCRIPTION
## Summary
- redesign site layout with modern CSS classes
- modernize product card style
- revamp chat widget markup and styling
- enable draggable and resizable chat window

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6847621136d88325b52a2372906a41df