### PR TITLE
Add alternate light theme

### DIFF
--- a/static/shop/css/alt-theme.css
+++ b/static/shop/css/alt-theme.css
@@ -1,0 +1,47 @@
+/* Link this file instead of theme.css to switch to the alt brand theme */
+:root {
+  --primary: #FF5722;
+  --secondary: #546E7A;
+  --background: #F9F9F9;
+  --text-color: #212121;
+  --radius: 0.5rem;
+  --font-family: 'Inter', sans-serif;
+
+  --bs-body-bg: var(--background);
+  --bs-body-color: var(--text-color);
+  --bs-border-radius: var(--radius);
+  --bs-primary: var(--primary);
+  --bs-primary-rgb: 255,87,34;
+  --bs-secondary: var(--secondary);
+  --bs-secondary-rgb: 84,110,122;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #121212;
+    --text-color: #F9F9F9;
+
+    --bs-body-bg: var(--background);
+    --bs-body-color: var(--text-color);
+  }
+}
+
+body {
+  background: var(--bs-body-bg);
+  color: var(--bs-body-color);
+  font-family: var(--font-family);
+}
+
+.modern-body {
+  background: var(--bs-body-bg);
+  min-height: 100vh;
+}
+
+.bg-brand {
+  background-color: var(--primary) !important;
+  color: #fff !important;
+}
+
+.text-muted-secondary {
+  color: var(--secondary) !important;
+}

--- a/templates/shop/base.html
+++ b/templates/shop/base.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{% static 'shop/css/alt-theme.css' %}">
   <link rel="stylesheet" href="{% static 'css/theme.css' %}">
   <link rel="stylesheet" href="{% static 'shop/css/chat.css' %}">
   <meta name="viewport" content="width=device-width,initial-scale=1">


### PR DESCRIPTION
## Summary
- add `alt-theme.css` for brand colors and dark mode support
- link new alt theme in `base.html` between Bootstrap and theme.css

## Testing
- `python manage.py check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_684770a93e1883258dbb29155d487d6d