### PR TITLE
Add responsive chat styles

### DIFF
--- a/static/css/chatbot.css
+++ b/static/css/chatbot.css
@@ -1,0 +1,79 @@
+/*
+Color variables: --cb-header-bg controls the header background; --cb-header-color sets header text/icon color; --cb-card-bg is the widget background; --cb-border-color defines borders and subtle shadows; --cb-bot-bg and --cb-bot-color style bot messages; --cb-user-bg and --cb-user-color style user messages. Override these CSS variables or Bootstrap variables to adjust the palette.
+*/
+
+#chatbot-container {
+  width: clamp(320px, 420px, 560px);
+  background: var(--cb-card-bg, #fff);
+  border-radius: 8px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.1);
+  border: 1px solid var(--cb-border-color, rgba(0, 0, 0, 0.1));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  font-family: var(--bs-body-font-family, sans-serif);
+}
+
+#chatbot-container .chatbot-header {
+  background: var(--cb-header-bg, var(--bs-primary));
+  color: var(--cb-header-color, #fff);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+}
+
+#chatbot-container .chatbot-header img {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+#chatbot-container .chatbot-close {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1.25rem;
+  opacity: 0.7;
+}
+
+#chatbot-container .chatbot-messages {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 1rem;
+  background: var(--cb-messages-bg, #f8f9fa);
+}
+
+#chatbot-container .chatbot-message {
+  border-radius: 12px;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.5rem;
+  display: inline-block;
+  max-width: 80%;
+}
+
+#chatbot-container .chatbot-message.bot {
+  background: var(--cb-bot-bg, var(--bs-light, #e9ecef));
+  color: var(--cb-bot-color, var(--bs-body-color, #212529));
+  margin-right: auto;
+}
+
+#chatbot-container .chatbot-message.user {
+  background: var(--cb-user-bg, var(--bs-primary));
+  color: var(--cb-user-color, #fff);
+  margin-left: auto;
+  text-align: right;
+}
+
+#chatbot-container form {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  border-top: 1px solid var(--cb-border-color, rgba(0, 0, 0, 0.1));
+}
+
+#chatbot-container form .form-control {
+  flex: 1 1 auto;
+}

--- a/templates/chatbot_sample.html
+++ b/templates/chatbot_sample.html
@@ -1,0 +1,16 @@
+<div id="chatbot-container" class="shadow">
+  <div class="chatbot-header">
+    <img src="{% static 'shop/img/bot-avatar.png' %}" alt="Bot" />
+    <strong>Support Bot</strong>
+    <button class="chatbot-close" aria-label="Close">&times;</button>
+  </div>
+  <div class="chatbot-messages">
+    <div class="chatbot-message bot">Hello! How can I help you?</div>
+    <div class="chatbot-message user">I need assistance.</div>
+  </div>
+  <form method="post">
+    {% csrf_token %}
+    <input type="text" class="form-control" placeholder="Type your message" />
+    <button class="btn btn-primary" type="submit">Send</button>
+  </form>
+</div>


### PR DESCRIPTION
## Summary
- add new `chatbot.css` with responsive styles for #chatbot-container
- provide sample HTML snippet showing chat widget structure

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68477b8264e083259f6daf0d470dec8d