### PR TITLE
Enhance chatbot window with drag+resize

### DIFF
--- a/static/shop/css/chat.css
+++ b/static/shop/css/chat.css
@@ -1,5 +1,10 @@
 #chatbot-container {
+    position: fixed;
+    right: 1rem;
+    bottom: 1rem;
     width: clamp(320px, 90vw, 560px);
+    min-height: 260px;
+    max-height: 720px;
     background: #FFF;
     border-radius: 12px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
@@ -78,4 +83,13 @@
     background: #FF9800;
     border-color: #FF9800;
     color: #263238;
+}
+
+#chatbot-container .chatbot-resize-handle {
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    right: 0;
+    bottom: 0;
+    cursor: se-resize;
 }

--- a/static/shop/js/chat.js
+++ b/static/shop/js/chat.js
@@ -106,3 +106,90 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 });
+
+document.addEventListener('DOMContentLoaded', () => {
+    const container = document.getElementById('chatbot-container');
+    const header = container?.querySelector('.chatbot-header');
+    if (!container || !header) return;
+
+    container.style.position = 'fixed';
+    const pos = JSON.parse(localStorage.getItem('chatbotPos') || 'null');
+    const size = JSON.parse(localStorage.getItem('chatbotSize') || 'null');
+    if (size) {
+        container.style.width = size.width + 'px';
+        container.style.height = size.height + 'px';
+    }
+    if (pos) {
+        container.style.left = pos.left + 'px';
+        container.style.top = pos.top + 'px';
+    } else {
+        container.style.right = '1rem';
+        container.style.bottom = '1rem';
+    }
+
+    const handle = document.createElement('div');
+    handle.className = 'chatbot-resize-handle';
+    container.appendChild(handle);
+
+    let drag = false, offsetX = 0, offsetY = 0;
+    header.addEventListener('mousedown', e => {
+        drag = true;
+        offsetX = e.clientX - container.offsetLeft;
+        offsetY = e.clientY - container.offsetTop;
+        document.body.style.userSelect = 'none';
+    });
+
+    let resize = false, startX = 0, startY = 0, startW = 0, startH = 0;
+    handle.addEventListener('mousedown', e => {
+        resize = true;
+        startX = e.clientX;
+        startY = e.clientY;
+        startW = container.offsetWidth;
+        startH = container.offsetHeight;
+        document.body.style.userSelect = 'none';
+        e.stopPropagation();
+    });
+
+    const clamp = (val, min, max) => Math.min(Math.max(val, min), max);
+    const savePos = () => localStorage.setItem('chatbotPos', JSON.stringify({
+        left: container.offsetLeft,
+        top: container.offsetTop
+    }));
+    const saveSize = () => localStorage.setItem('chatbotSize', JSON.stringify({
+        width: container.offsetWidth,
+        height: container.offsetHeight
+    }));
+
+    document.addEventListener('mousemove', e => {
+        if (drag) {
+            const vw = document.documentElement.clientWidth;
+            const vh = document.documentElement.clientHeight;
+            let l = e.clientX - offsetX;
+            let t = e.clientY - offsetY;
+            l = clamp(l, 0, vw - container.offsetWidth);
+            t = clamp(t, 0, vh - container.offsetHeight);
+            container.style.left = l + 'px';
+            container.style.top = t + 'px';
+        } else if (resize) {
+            let w = startW + e.clientX - startX;
+            let h = startH + e.clientY - startY;
+            w = clamp(w, 320, 560);
+            h = clamp(h, 260, 720);
+            container.style.width = w + 'px';
+            container.style.height = h + 'px';
+        }
+    });
+
+    document.addEventListener('mouseup', () => {
+        if (drag) {
+            drag = false;
+            document.body.style.userSelect = '';
+            savePos();
+        }
+        if (resize) {
+            resize = false;
+            document.body.style.userSelect = '';
+            saveSize();
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- allow chatbot window to be dragged by its header
- allow resizing from bottom-right handle
- remember position & size in localStorage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68478645e3d8832591ec8be51b90ae15