### PR TITLE
Add resize support for chatbox

### DIFF
--- a/static/shop/css/chat.css
+++ b/static/shop/css/chat.css
@@ -1,4 +1,5 @@
-#chatbot-container {
+#chatbot-container,
+#chatbox {
     position: fixed;
     right: 1rem;
     bottom: 1rem;
@@ -85,7 +86,8 @@
     color: #263238;
 }
 
-#chatbot-container .chatbot-resize-handle {
+#chatbot-container .chatbot-resize-handle,
+#chatbox .chatbot-resize-handle {
     position: absolute;
     width: 16px;
     height: 16px;


### PR DESCRIPTION
## Summary
- allow `#chatbox` to reuse `chat.css` styles
- style resize handle inside chatbox as well

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68479368d22c83258962cd224373fe80