### PR TITLE
Enable safe SQL queries and improve chat UI

### DIFF
--- a/shop/tests/test_chat_api.py
+++ b/shop/tests/test_chat_api.py
@@ -1,0 +1,34 @@
+import os
+import django
+from django.urls import reverse
+from django.test import TestCase
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "exeshop.settings")
+os.environ.setdefault("ALLOWED_HOSTS", "testserver")
+django.setup()
+
+from shop.chat_api import _run_safe_sql
+from shop.models import Category, Product
+
+
+class ChatApiTests(TestCase):
+    def setUp(self):
+        self.cat = Category.objects.create(name="Cat", slug="cat")
+        Product.objects.create(category=self.cat, name="A", slug="a", description="d", price=1)
+
+    def test_run_safe_sql_valid(self):
+        rows = _run_safe_sql("SELECT name, price FROM Product")
+        self.assertEqual(rows[0]["name"], "A")
+
+    def test_run_safe_sql_invalid(self):
+        self.assertIsNone(_run_safe_sql("DELETE FROM Product"))
+
+    def test_chat_sql_endpoint(self):
+        url = reverse("shop:chat_api")
+        resp = self.client.post(
+            url,
+            data="{\"message\": \"#sql: SELECT name FROM Product\"}",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("| name |", resp.json()["answer"])

--- a/static/shop/css/chat.css
+++ b/static/shop/css/chat.css
@@ -1,3 +1,20 @@
+:root {
+    --cb-bg: #fff;
+    --cb-text: #263238;
+    --cb-accent: #FF9800;
+    --cb-header-bg: #263238;
+    --cb-header-text: #fff;
+}
+@media (prefers-color-scheme: dark) {
+    :root {
+        --cb-bg: #182026;
+        --cb-text: #eee;
+        --cb-accent: #ffb74d;
+        --cb-header-bg: #37474F;
+        --cb-header-text: #fff;
+    }
+}
+
 #chatbot-container {
     position: fixed;
     right: 1rem;
@@ -5,23 +22,26 @@
     width: clamp(320px, 90vw, 560px);
     min-height: 260px;
     max-height: 720px;
-    background: #FFF;
+    background: var(--cb-bg);
+    color: var(--cb-text);
     border-radius: 12px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
     border: 1px solid rgba(0, 0, 0, 0.1);
     display: flex;
     flex-direction: column;
-    overflow: hidden;
+    overflow: auto;
+    resize: both;
     font-family: var(--bs-body-font-family, sans-serif);
 }
 
 #chatbot-container .chatbot-header {
-    background: #263238;
-    color: #FFF;
+    background: var(--cb-header-bg);
+    color: var(--cb-header-text);
     display: flex;
     align-items: center;
     gap: 0.5rem;
     padding: 0.75rem 1rem;
+    cursor: move;
 }
 
 #chatbot-container .chatbot-header img {
@@ -44,7 +64,7 @@
     flex: 1 1 auto;
     overflow-y: auto;
     padding: 1rem;
-    background: #FFF;
+    background: var(--cb-bg);
 }
 
 #chatbot-container .chatbot-message {
@@ -56,14 +76,14 @@
 }
 
 #chatbot-container .chatbot-message.bot {
-    background: #263238;
-    color: #FFF;
+    background: var(--cb-header-bg);
+    color: var(--cb-header-text);
     margin-right: auto;
 }
 
 #chatbot-container .chatbot-message.user {
-    background: #FF9800;
-    color: #263238;
+    background: var(--cb-accent);
+    color: var(--cb-text);
     margin-left: auto;
     text-align: right;
 }
@@ -80,19 +100,8 @@
 }
 
 #chatbot-container .btn-primary {
-    background: #FF9800;
-    border-color: #FF9800;
-    color: #263238;
+    background: var(--cb-accent);
+    border-color: var(--cb-accent);
+    color: var(--cb-text);
 }
 
-#chatbot-container .chatbot-resize-handle {
-    position: absolute;
-    width: 16px;
-    height: 16px;
-    right: 0;
-    bottom: 0;
-    cursor: se-resize;
-    border-right: 2px solid #ccc;
-    border-bottom: 2px solid #ccc;
-    box-sizing: border-box;
-}


### PR DESCRIPTION
## Summary
- allow read-only SQL queries for Product and Order via `#sql:`
- add helper functions `_run_safe_sql` and `_table_to_md`
- detect simple natural language queries via ORM
- make chat window draggable and resizable; store position/size
- add dark mode support for chat styles
- create pytest coverage for chat API

## Testing
- `ruff check shop static/shop/js/chat.js static/shop/css/chat.css`
- `DJANGO_SETTINGS_MODULE=exeshop.settings PYTHONPATH=. pytest shop/tests/test_chat_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6847998a5f2c8325967362df07018925